### PR TITLE
Switch to actions v4

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Archive the result
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: website
           path: |


### PR DESCRIPTION
projects hosted on GitHub and utilizing actions should take note that GitHub has issued a deprecation notice for some commonly used actions.

* actions/upload-artifact
* actions/download-artifact

The following versions are deprecated and will stop working in the not so near future:

* v1 and v2: from 30/06/2024
* v3: from 30/11/2024

It is highly encouraged to update to v4 of these actions asap to avoid any disruption. See more details at:

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Best regards,
Thomas Neidhart