### PR TITLE
Fix documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,28 +4,22 @@ name: Deploy to Github Pages
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main test ]
-    
-  pull_request_target:
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-
   # This workflow contains a single job called "build"
   build:
-
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       # Runs a set of commands using the runners shell
       - name: Docusaurus build
@@ -35,15 +29,15 @@ jobs:
 
       # Archive the result
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: website
           path: |
             build
-      
+
       # Deploy to ghpages branch
       - name: Deploy Github Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
This PR fixes the current documentation workflow:

- disable pull_request_trigger trigger
- pin actions

It does not make sense to add a pull_request_trigger for building the GH Pages website as an PR will overwrite the currently deployed page.

If you want a preview feature, take a look at the https://github.com/eclipse-langium/langium-website/blob/main/.github/workflows/preview.yml workflow that publishes the site from PRs to a separate repo for inspection and adds a link to the PR itself. If you like this approach we can help you set this up, open a ticket in the HelpDesk about it.

cc @wimjongman 